### PR TITLE
change model output json to user friendly indented output json

### DIFF
--- a/podder_task_foundation/objects/array.py
+++ b/podder_task_foundation/objects/array.py
@@ -26,7 +26,10 @@ class Array(Object):
         return self._data[item]
 
     def to_json(self) -> str:
-        return json.dumps(self._data, cls=NumpyJsonEncoder, ensure_ascii=False)
+        return json.dumps(self._data,
+                          cls=NumpyJsonEncoder,
+                          ensure_ascii=False,
+                          indent=4)
 
     def save(self, path: Path, encoding: Optional[str] = 'utf-8') -> bool:
         file_type = DataFileLoader().get_file_type(path)

--- a/podder_task_foundation/objects/dictionary.py
+++ b/podder_task_foundation/objects/dictionary.py
@@ -36,7 +36,10 @@ class Dictionary(Object):
         return item in self._data.keys()
 
     def to_json(self) -> str:
-        return json.dumps(self._data, cls=NumpyJsonEncoder, ensure_ascii=False)
+        return json.dumps(self._data,
+                          cls=NumpyJsonEncoder,
+                          ensure_ascii=False,
+                          indent=4)
 
     def save(self, path: Path, encoding: Optional[str] = 'utf-8') -> bool:
         file_type = DataFileLoader().get_file_type(path)


### PR DESCRIPTION
I changed model output json to user friendly indented output json.

before
```["foo", {"bar":["baz", null, 1.0, 2]}]```
after
```
[
    "foo", 
    {
        "bar": [
            "baz", 
            null, 
            1.0, 
            2
        ]
    }
]
```