### PR TITLE
Feature/add custom logger handler

### DIFF
--- a/podder_task_foundation/logging/loggers/base_logger.py
+++ b/podder_task_foundation/logging/loggers/base_logger.py
@@ -54,8 +54,6 @@ class BaseLogger(object):
         self._format(logging.CRITICAL, msg, extra=self._create_extra(), *args, **kwargs)
 
     def add_handler(self, handler: logging.StreamHandler):
-        if self._logger.hasHandlers():
-            self._logger.handlers.clear()
         self._logger.addHandler(handler)
         
     @staticmethod

--- a/podder_task_foundation/logging/loggers/base_logger.py
+++ b/podder_task_foundation/logging/loggers/base_logger.py
@@ -53,6 +53,11 @@ class BaseLogger(object):
     def critical(self, msg, *args, **kwargs):
         self._format(logging.CRITICAL, msg, extra=self._create_extra(), *args, **kwargs)
 
+    def add_handler(self, handler: logging.StreamHandler):
+        if self._logger.hasHandlers():
+            self._logger.handlers.clear()
+        self._logger.addHandler(handler)
+        
     @staticmethod
     def _convert_newline_character(msg: str) -> str:
         if not isinstance(msg, str):

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -16,5 +16,5 @@ def test_logger_add_handler():
     assert context.logger
     before_handler_number = len(context.logger._logger.handlers)
     null_handler = logging.NullHandler()
-    assert context.logger.add_handler(null_handler)
+    context.logger.add_handler(null_handler)
     assert len(context.logger._logger.handlers) == before_handler_number + 1

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import logging
+
+from podder_task_foundation import MODE, Context, Payload, Process
+
+
+def test_logger_create():
+    context = Context(mode=MODE.TEST, config_path=Path(__file__).parent.joinpath("data", "config"))
+    assert context
+    assert context.logger
+
+
+def test_logger_add_handler():
+    context = Context(mode=MODE.TEST, config_path=Path(__file__).parent.joinpath("data", "config"))
+    assert context
+    assert context.logger
+    before_handler_number = len(context.logger._logger.handlers)
+    null_handler = logging.NullHandler()
+    assert context.logger.add_handler(null_handler)
+    assert len(context.logger._logger.handlers) == before_handler_number + 1


### PR DESCRIPTION
podder task foundationのloggerにCloudLoggingHandlerとか追加できるように改修しました。

背景: HSBCの案件で、Google Cloud Loggingへログを流す必要があるので、logger/handlerへ追加する必要があります。

- [x] BaseLogger.addHandlerを追加しました。
- [x] test_logger.pyを追加しました。