### PR TITLE
Change to support multiple directory inputs

### DIFF
--- a/podder_task_foundation/process_executor.py
+++ b/podder_task_foundation/process_executor.py
@@ -97,7 +97,7 @@ class ProcessExecutor(object):
         _input = Payload()
         for name, path in files:
             if path.is_dir():
-                _input.add_directory(directory=path)
+                _input.add_directory(directory=path, name=name)
             else:
                 _input.add_file(file=path, name=name)
 


### PR DESCRIPTION
I changed the input handling code to support multiple directory inputs.

Example
`poetry run python manage.py process_name --input dir1=input/directory1 dir2=input/directory2`