### PR TITLE
Change for output type: directory

### DIFF
--- a/podder_task_foundation/objects/directory.py
+++ b/podder_task_foundation/objects/directory.py
@@ -50,6 +50,12 @@ class Directory(Object):
 
         return True
 
+    def get_file_name(self, base_path: Optional[Path] = None) -> Path:
+        path = base_path
+        if base_path is None:
+            path = Path(self._name)
+        return path
+
     @classmethod
     def load(cls, path: Path, name: Optional[str] = None) -> "Directory":
         if not path.is_dir():


### PR DESCRIPTION
With the current code, if we specify a directory for output, created a directory unexpected name. To fix it, I change add `get_file_name` function to Directory class. 

Execution command
```
poetry run python manage.py process_name --input /path/to/input_dirctory --output sample=/path/to/output_dirctory
```

As is:
/path/to/output_dirctory/sample.pkl/

To be:
/path/to/output_dirctory/